### PR TITLE
More testable "*.sc" scripts and a test harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ tests: $(test_logs)
 # Test each script by running it. The log will be mostly empty
 # of output, often just containing the command that was run.
 $(output_dir)/%.log: src/main/%.sc
-	@echo "Testing: $@ ..." 1>&2
+	@echo "Testing: $< (output: $@) ..." 1>&2
 	@mkdir -p $$(dirname $@)
 	@echo scala $(scala_options) $< > $@
 	@scala $(scala_options) $< >> $@

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ clean:
 
 tests: $(test_logs)
 
-# Test all the scripts by running them. The logs will be mostly of output,
-# often just containing the command that was run.
+# Test each script by running it. The log will be mostly empty
+# of output, often just containing the command that was run.
 $(output_dir)/%.log: src/main/%.sc
 	@echo "Testing: $@ ..." 1>&2
 	@mkdir -p $$(dirname $@)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.2
+sbt.version=1.3.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,3 @@ resolvers ++= Seq(
   "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 )
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
-


### PR DESCRIPTION
More refinements to the testability of scripts. Most of the "*.sc" scripts have been refactored to make them more testable, e.g., by asserting expected behavior, so that simply running them will find failures. There is now a Makefile that does this process. It finds all the scripts and runs them, failing if any of them fail to compile or an assertion fails. In some cases scripts were converted to code or "*.scX", because they are designed to fail!