### PR TITLE
Fix a unit test in PathSuite

### DIFF
--- a/src/test/scala/progscala3/rounding/PathSuite.scala
+++ b/src/test/scala/progscala3/rounding/PathSuite.scala
@@ -22,5 +22,5 @@ class PathSuite extends FunSuite:
   }
   test("concatenation with the infix 'append'") {
     val a = Path("a")
-    assert(Path("a/b") == (a append "b"))
+    assert(Path(s"a${Path.defaultSeparator}b") == (a append "b"))
   }


### PR DESCRIPTION
The original one only works when the `Path.defaultSeparator` is `"/"`, which means it doesn't work in Windows.