### PR TITLE
Fix tests failing when LANG="en_US.UTF-8" environment variable not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,28 +169,6 @@ HELLO WORLD!
 $
 ```
 
-### Build Troubleshooting
-
-Here are tips for issues users have reported.
-
-#### Internationalization
-
-I didn't check that the tests pass or the scripts work if your language environment isn't English. So, no surprise I guess, a German user reported that three tests failed when running `sbt test` while the `LANG` was set to `de_DE.UTF-8`:
-
-```
-[info] Passed: Total 7, Failed 0, Errors 0, Passed 7
-[error] Failed: Total 233, Failed 7, Errors 0, Passed 226
-[error] Failed tests:
-[error]         progscala3.fp.combinators.PayrollSuite
-[error]         progscala3.fp.curry.TupledFuncSuite
-[error]         progscala3.dsls.payroll.PayrollSuite
-[error] (Test / test) sbt.TestsFailedException: Tests unsuccessful
-[error] Total time: 2 s, completed 31.07.2021, 16:56:39
-```
-
-
-Setting `export LANG="en_US.UTF-8"; sbt test` works. A PR for this is welcome ;) As an interim step, you could wrap this logic (or the more concise single command `LANG="en_US.UTF-8" sbt test`) in a script or just ignore the three failing tests.
-
 ## Feedback
 
 I welcome feedback on the Book and these examples. Please post comments, corrections, etc. to one of the following places:

--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,10 @@ lazy val root = project
       // "-Yexplicit-nulls",                  // For explicit nulls behavior.
     ),
     Compile / console / scalacOptions := scalacOptions.value,
+    fork := true,
+    javaOptions ++= Seq(
+      "-Duser.language=en_US"
+    ),
     javacOptions ++= Seq(
       "-Xlint:unchecked", "-Xlint:deprecation") // Java 8: "-Xdiags:verbose"),
   )


### PR DESCRIPTION
Hi @deanwampler,

Here's fix for tests failing when locale are different than en_US - issue #39. As an alternative in Intellij Idea it is possible to add -Duser.language=en_US JVM flag in Settings -> Build, Execution, Deployment -> sbt in VM parameters field.

Fix tested with following config:

- sbt 1.55
- AdoptOpenJDK 11
- Ubuntu 21.04
- LANG env variable set to pl_PL.UTF-8

Thank you for writing the book, I have really enjoyed learning with it so far.