### PR TITLE
Fixed synchronize bugs (issue #104

### DIFF
--- a/src/main/scala/progscala3/traits/ui/ButtonCountObserver.scala
+++ b/src/main/scala/progscala3/traits/ui/ButtonCountObserver.scala
@@ -2,7 +2,11 @@
 package progscala3.traits.ui
 import progscala3.traits.observer.*
 
+/*
+ * 2024-02-24: Changed the original count.synchronized {...} to this.synchronized {...},
+ * because the former was wrong for a primitive. So now we synchronize on the instance.
+ */
 class ButtonCountObserver extends Observer[Button]:
   var count = 0
   def receiveUpdate(state: Button): Unit =
-    count.synchronized { count += 1 }
+    this.synchronized { count += 1 } 

--- a/src/main/scala/progscala3/traits/ui2/CountObserver.scala
+++ b/src/main/scala/progscala3/traits/ui2/CountObserver.scala
@@ -2,6 +2,10 @@
 package progscala3.traits.ui2
 import progscala3.traits.observer.*
 
+/*
+ * 2024-02-24: Changed the original count.synchronized {...} to this.synchronized {...},
+ * because the former was wrong for a primitive. So now we synchronize on the instance.
+ */
 trait CountObserver[State] extends Observer[State]:
   var count = 0
-  def receiveUpdate(state: State): Unit = count.synchronized { count += 1 }
+  def receiveUpdate(state: State): Unit = this.synchronized { count += 1 }

--- a/src/main/scala/progscala3/traits/ui2/VetoableClicks.scala
+++ b/src/main/scala/progscala3/traits/ui2/VetoableClicks.scala
@@ -1,15 +1,19 @@
 // src/main/scala/progscala3/traits/ui2/VetoableClicks.scala
 package progscala3.traits.ui2
 
+/*
+ * 2024-02-24: Changed the original count.synchronized {...} to this.synchronized {...},
+ * because the former was wrong for a primitive. So now we synchronize on the instance.
+ */
 trait VetoableClicks(val maxAllowed: Int = 1) extends Clickable:     // <1>
   private var count = 0                                              // <2>
 
   abstract override def click(): String =
-    count.synchronized { count += 1 }
+    this.synchronized { count += 1 }
     if count <= maxAllowed then                                      // <3>
       super.click()
     else
       s"Max allowed clicks $maxAllowed exceeded. Received $count clicks!"
 
-  def resetCount(): Unit = count.synchronized { count = 0 }          // <4>
+  def resetCount(): Unit = this.synchronized { count = 0 }          // <4>
 


### PR DESCRIPTION
Fixes #104. Apparently Scala as of 3.4 catches the error of trying to synchronize on a primitive. This PR replaces the four occurrences of `count.synchronized {...}` with `this.synchronized {...}`, synchronizing on the whole instance, which is almost the same since all the types involved only have a single `int` field named `count` in all cases.